### PR TITLE
Update to 3.1.0

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nordlayer
 	pkgdesc = Proprietary VPN client for linux
-	pkgver = 3.0.0
+	pkgver = 3.1.0
 	pkgrel = 0
 	url = https://nordlayer.com
 	install = nordlayer.install
@@ -12,7 +12,7 @@ pkgbase = nordlayer
 	replaces = nordvpnteams-bin
 	options = !strip
 	options = !emptydirs
-	source_x86_64 = https://downloads.nordlayer.com/linux/latest/debian/pool/main/nordlayer_3.0.0_amd64.deb
-	sha512sums_x86_64 = ab268ec215022eca8f6a8f82b20e559a1e4eba89e088550b09b80306eba6ca07ce3a22880f277c780541449f5d9f9f933e952015d8614c52af83071fd980eaaa
+	source_x86_64 = https://downloads.nordlayer.com/linux/latest/debian/pool/main/nordlayer_3.1.0_amd64.deb
+	sha512sums_x86_64 = 8e8f369db2bd6ada11564ab8be06f9faa6efa1a11f324956698c3b8b2da8a489ca685ed68e4e775e05e17e363a661f0af6e5c05d6d3cff76ed83e032ef815cdb
 
 pkgname = nordlayer

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Deividas Gedgaudas <sidicer at gmail dot com>
 
 pkgname=nordlayer
-pkgver=3.0.0
+pkgver=3.1.0
 pkgrel=0
 pkgdesc="Proprietary VPN client for linux"
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ depends=('bash')
 options=('!strip' '!emptydirs')
 install=${pkgname}.install
 source_x86_64=("https://downloads.nordlayer.com/linux/latest/debian/pool/main/${pkgname}_${pkgver}_amd64.deb")
-sha512sums_x86_64=('ab268ec215022eca8f6a8f82b20e559a1e4eba89e088550b09b80306eba6ca07ce3a22880f277c780541449f5d9f9f933e952015d8614c52af83071fd980eaaa')
+sha512sums_x86_64=('8e8f369db2bd6ada11564ab8be06f9faa6efa1a11f324956698c3b8b2da8a489ca685ed68e4e775e05e17e363a661f0af6e5c05d6d3cff76ed83e032ef815cdb')
 
 package(){
 	# Extract package data

--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ sudo setcap 'CAP_NET_ADMIN+eip CAP_DAC_OVERRIDE+eip CAP_SETUID+eip' /usr/libexec
 sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-setcap
 sudo setcap 'CAP_NET_ADMIN=+eip' /usr/bin/nordlayer
 ```
+
+Remember to reboot after changes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Nordlayer](https://nordlayer.com) VPN package for Linux (esp [ArchLinux](https://archlinux.org/)) 
-[![AUR version](https://img.shields.io/aur/version/nordlayer)](https://aur.archlinux.org/packages/nordlayer) [![Nordlayer version](https://img.shields.io/badge/nordlayer-3.0.0-green)](https://nordlayer.com/download/linux/)
+[![AUR version](https://img.shields.io/aur/version/nordlayer)](https://aur.archlinux.org/packages/nordlayer) [![Nordlayer version](https://img.shields.io/badge/nordlayer-3.1.0-green)](https://nordlayer.com/download/linux/)
 
 ### Hotfix (Version 2.6.5) released by Nordlayer
 The new version should not break `nordlayer.db` 
@@ -12,9 +12,6 @@ nordlayer login
 ```
 
 ### Important
-Original [repository](https://github.com/mearaj/nordlayer) was archived by [mearaj](https://github.com/mearaj) as they are longer a nordlayer user.<br>
-I will be maintaining the package from now on.
-
 If you run into any errors feel free to create an [issue](https://github.com/Sidicer/nordlayer/issues/new) or leave a comment [in AUR](https://aur.archlinux.org/packages/nordlayer)
 
 To check latest official [nordlayer](https://nordlayer.com) version:
@@ -29,9 +26,9 @@ yay -S nordlayer
 
 ### Building the package manually:
 ```sh
-git clone https://github.com/Sidicer/nordlayer.git
+git clone https://github.com/akumaburn/nordlayer-latest.git
 cd nordlayer
 makepkg -si
 # If 'makepkg -si' fails to install automatically:
-sudo pacman -U nordlayer-3.0.0-0-x86_64.pkg.tar.zst
+sudo pacman -U nordlayer-3.1.0-0-x86_64.pkg.tar.zst
 ```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ makepkg -si
 # If 'makepkg -si' fails to install automatically:
 sudo pacman -U nordlayer-3.1.0-0-x86_64.pkg.tar.zst
 ```
+
+### Connection Error fix:
+```
+sudo usermod -a -G nordlayer $(whoami)
+sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-charon
+sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-ip
+sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-openvpn
+sudo setcap 'CAP_NET_ADMIN+eip CAP_DAC_OVERRIDE+eip CAP_SETUID+eip' /usr/libexec/nordlayer/nordlayer-resolvconf
+sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-setcap
+sudo setcap 'CAP_NET_ADMIN=+eip' /usr/bin/nordlayer
+```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yay -S nordlayer
 ### Building the package manually:
 ```sh
 git clone https://github.com/akumaburn/nordlayer-latest.git
-cd nordlayer
+cd nordlayer-latest
 makepkg -si
 # If 'makepkg -si' fails to install automatically:
 sudo pacman -U nordlayer-3.1.0-0-x86_64.pkg.tar.zst


### PR DESCRIPTION
Updated to 3.1.0 , added instructions for permissions issue as well.

The strace output shows that the nordlayer-resolvconf process is attempting to execute a setuid(0) system call and is failing with EPERM (Operation not permitted). This indicates that the process is trying to gain root privileges, but it's being denied.

I fixed with:

```
sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-charon
sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-ip
sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-openvpn
sudo setcap 'CAP_NET_ADMIN+eip CAP_DAC_OVERRIDE+eip CAP_SETUID+eip' /usr/libexec/nordlayer/nordlayer-resolvconf
sudo setcap 'CAP_NET_ADMIN=+eip' /usr/libexec/nordlayer/nordlayer-setcap
sudo setcap 'CAP_NET_ADMIN=+eip' /usr/bin/nordlayer
```

Remember to also run:

`sudo usermod -a -G nordlayer $(whoami)`

and reboot.